### PR TITLE
Fix: Always route dominant speaker even if not in loudest set

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/ConferenceSpeechActivity.java
@@ -128,9 +128,27 @@ public class ConferenceSpeechActivity
         dominantSpeakerIdentification = new DominantSpeakerIdentification<>(silenceTimeoutMs);
 
         dominantSpeakerIdentification.addActiveSpeakerChangedListener(activeSpeakerChangedListener);
-        int numLoudestToTrack = LoudestConfig.Companion.getRouteLoudestOnly() ?
-                LoudestConfig.Companion.getNumLoudest() : 0;
-        dominantSpeakerIdentification.setLoudestConfig(numLoudestToTrack,
+        int numLoudestToTrack;
+        if (LoudestConfig.Companion.getRouteLoudestOnly())
+        {
+            if (LoudestConfig.Companion.getAlwaysRouteDominant())
+            {
+                // If we are always routing the dominant speaker, we need to
+                // track all speakers to identify the dominant one.
+                numLoudestToTrack = 200;
+            }
+            else
+            {
+                numLoudestToTrack = LoudestConfig.Companion.getNumLoudest();
+            }
+        }
+        else
+        {
+            numLoudestToTrack = 0;
+        }
+
+        dominantSpeakerIdentification.setLoudestConfig(
+                numLoudestToTrack,
                 (int)(LoudestConfig.Companion.getEnergyExpireTime().toMillis()),
                 LoudestConfig.Companion.getEnergyAlphaPct());
     }


### PR DESCRIPTION
The dominant speaker detection logic was being configured to only track a set number of speakers, determined by the `num-loudest` configuration property. This prevented a speaker from being identified as dominant if they were not already in this loudest set, even when the `always-route-dominant` setting was enabled.

This change modifies the dominant speaker detection configuration. When `always-route-dominant` is true, the system will now track a much larger pool of speakers (200), ensuring that any participant can be identified as the dominant speaker, regardless of their historical audio energy. This aligns the behavior with the intention of the configuration, allowing the dominant speaker's audio to be routed correctly.